### PR TITLE
removing iPhone-specific key codes

### DIFF
--- a/jquery.meio.mask.js
+++ b/jquery.meio.mask.js
@@ -127,10 +127,7 @@
                 224  : 'command'
             },
 
-            iphoneKeyRepresentation: {
-                10    : 'go',
-                127   : 'delete'
-            },
+            
 
             signals: {
                 '+' : '',
@@ -186,7 +183,7 @@
                 if (!this.hasInit) {
 
                     var self = this, i,
-                        keyRep = (isIphone) ? this.iphoneKeyRepresentation : this.keyRepresentation;
+                        keyRep = this.keyRepresentation;
 
                     this.ignore = false;
 


### PR DESCRIPTION
the iPhone actually uses 8 for delete now, so deleting text in a masked field was broken!
